### PR TITLE
Feat: Add quick join functionality

### DIFF
--- a/src/events/events.ts
+++ b/src/events/events.ts
@@ -17,6 +17,8 @@ export enum RoomEvents {
   ROOM_UPDATED = 'room_updated',
   PLAYER_JOINED = 'player_joined',
   PLAYER_LEFT = 'player_left',
+  QUICK_JOIN = 'quick_join',
+  NO_ROOMS_AVAILABLE = 'no_rooms_available',
 }
 
 // Game play events

--- a/src/events/room.events.ts
+++ b/src/events/room.events.ts
@@ -21,6 +21,10 @@ export interface UpdateSettingsRequest extends BaseSocketMessage {
   config: RoomConfig;
 }
 
+export interface QuickJoinRequest extends BaseSocketMessage {
+  username: string;
+}
+
 // Response payloads
 export interface RoomResponse extends BaseSocketMessage {
   room: Room;

--- a/src/types/game.types.ts
+++ b/src/types/game.types.ts
@@ -12,6 +12,7 @@ export interface RoomConfig {
   attackDamage: number;
   healAmount: number;
   wrongAnswerPenalty: number;
+  isPublic: boolean;
 }
 
 export interface Room {


### PR DESCRIPTION
This pull request introduces a new "quick join" feature for rooms and includes several related updates to the codebase. The most important changes involve adding new events, interfaces, and methods to support this feature.

### New Events and Interfaces:
* [`src/events/events.ts`](diffhunk://#diff-340c6aa72375d168308e191917e1c0b984d7b662530fba8e2361513027400a54R20-R21): Added `QUICK_JOIN` and `NO_ROOMS_AVAILABLE` events to the `RoomEvents` enum.
* [`src/events/room.events.ts`](diffhunk://#diff-f48ea9b91376964dd96a84494af940273d82ea12de2902a67f4e4460927052f3R24-R27): Introduced a new `QuickJoinRequest` interface.

### Service Updates:
* [`src/services/room-service.ts`](diffhunk://#diff-9e293e38e594aa02ab7e235e914f57907a1aaa486a5b19ea28ed82266982a034R23): Updated the `createRoom` function to include an `isPublic` property in the room configuration. [[1]](diffhunk://#diff-9e293e38e594aa02ab7e235e914f57907a1aaa486a5b19ea28ed82266982a034R23) [[2]](diffhunk://#diff-9e293e38e594aa02ab7e235e914f57907a1aaa486a5b19ea28ed82266982a034R49)
* [`src/services/room-service.ts`](diffhunk://#diff-9e293e38e594aa02ab7e235e914f57907a1aaa486a5b19ea28ed82266982a034R140-R177): Added a new `quickJoin` function to handle the logic for joining the most suitable available public room.

### Socket Handlers:
* [`src/socket/handlers/room-handlers.ts`](diffhunk://#diff-95874443f5131ae4abfb9ccdd6807ead36ea1e058ed7511abd1a535729743dc6R7-R15): Imported the new `QuickJoinRequest` interface and `quickJoin` function.
* [`src/socket/handlers/room-handlers.ts`](diffhunk://#diff-95874443f5131ae4abfb9ccdd6807ead36ea1e058ed7511abd1a535729743dc6R85-R125): Added a new socket handler for the `QUICK_JOIN` event, which uses the `quickJoin` function and emits appropriate responses based on the result.

### Type Definitions:
* [`src/types/game.types.ts`](diffhunk://#diff-dd57d83d19d815c9f83674b33290e77d57da21dbd36a3fbfc902057542592e29R15): Updated the `RoomConfig` interface to include the `isPublic` property.